### PR TITLE
Feature/create login component#1

### DIFF
--- a/packages/newFront/public/index.html
+++ b/packages/newFront/public/index.html
@@ -21,6 +21,10 @@
     <link rel="preconnect" href="%REACT_APP_NODE_3%" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link href="https://fonts.googleapis.com/css2?family=Kanit:wght@400;600&display=swap" rel="stylesheet" />
+    <link href="https://db.onlinewebfonts.com/c/de5bbb2fd9d70781ae0507591a9700bd?family=Mister+Pixel+16+pt+-+Old+Style+Figure" rel="stylesheet" type="text/css"/>
+    <link href="https://db.onlinewebfonts.com/c/2dc1f3e11e010af30f075bf312c350cb?family=Mister+Pixel+16+pt+-+Regular" rel="stylesheet" type="text/css"/>
+    <link href="https://db.onlinewebfonts.com/c/6a496a907da2931948f3e10d85c14511?family=Mister+Pixel+16+pt+-+Small+Caps" rel="stylesheet" type="text/css"/>
+    <link href="https://db.onlinewebfonts.com/c/46882ecba04b7142961c1162cdaf65fc?family=Mister+Pixel+16+pt+-+ToolsOne" rel="stylesheet" type="text/css"/>
     <!-- <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" /> -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/packages/newFront/src/App.tsx
+++ b/packages/newFront/src/App.tsx
@@ -129,7 +129,6 @@ const App: React.FC = () => {
                 {/* <Route component={NotFound} /> */}
             </Switch>
           </SuspenseWithChunkError>
-          <Marginer />
         </Menu>
         <ToastListener />
       </Router>

--- a/packages/newFront/src/components/WalletModal/ConnectModal.tsx
+++ b/packages/newFront/src/components/WalletModal/ConnectModal.tsx
@@ -38,7 +38,7 @@ const ConnectModal: React.FC<Props> = ({ login, onDismiss = () => null }) => {
       />
     ))}
     <Button
-        width={100}
+        width="100%"
         variant="tertiary"
         onClick={() => {
           bscSwith("bsc")
@@ -52,7 +52,7 @@ const ConnectModal: React.FC<Props> = ({ login, onDismiss = () => null }) => {
         <BSC width="32px" />
     </Button>
     <Button
-        width={100}
+        width="100%"
         variant="tertiary"
         onClick={() => {
           bscSwith("chapel")

--- a/packages/newFront/src/hooks/useDynamicsSVGImport.ts
+++ b/packages/newFront/src/hooks/useDynamicsSVGImport.ts
@@ -20,7 +20,7 @@ const useDynamicSVGImport = (name: string, options: UseDynamicSVGImportOptions =
     const importIcon = async (): Promise<void> => {
       try {
         ImportedIconRef.current = (
-          await import(`!!@svgr/webpack?-svgo,+titleProp,+ref!../../../node_modules/cryptocurrency-icons/svg/color/${name}.svg`)
+          await import(`!!@svgr/webpack?-svgo,+titleProp,+ref!../../node_modules/cryptocurrency-icons/svg/color/${name}.svg`)
         ).default;
         onCompleted?.(name, ImportedIconRef.current);
       } catch (err) {

--- a/packages/newFront/src/views/Login.tsx
+++ b/packages/newFront/src/views/Login.tsx
@@ -1,6 +1,7 @@
 import { useWeb3React } from '@web3-react/core'
 import { useWalletModal } from 'components'
 import useAuth from 'hooks/useAuth'
+import { url } from 'inspector'
 import React from 'react'
 import styled from "styled-components"
 import { Login } from '../components/WalletModal/types'
@@ -14,8 +15,8 @@ interface Props {
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    background-color: black;
-    height: 100vh;
+    background-color: #030303;
+    height: calc(100vh - 63px);
 `
 const Button = styled.button`
 `
@@ -28,9 +29,10 @@ export default function LoginMain() {
     const { onPresentConnectModal, onPresentAccountModal } = useWalletModal(login, logout, account, history)
     return (
         <Container>
-            <img alt="CryptoZoo Logo" src="CryptoZooLogoFull.jpg"/>
-            <Button onClick={()=>onPresentConnectModal()}>
-                Log In
+            <img alt="CryptoZoo Logo" src="CryptoZooLogoFull.jpg" style={{width: '300px', margin: 'auto auto 30px auto'}}/>
+            <Button onClick={()=>onPresentConnectModal()} style={{width: '200px', margin: '0px auto auto auto', backgroundColor: '#030303', border: '1px solid #ffffff', padding: '10px'}}>
+                <p style={{color: 'white', fontFamily: "'Mister Pixel 16 pt - Small Caps'", fontSize: 16}}>LOGIN WITH</p>
+                <p style={{color: 'white', fontFamily: "'Mister Pixel 16 pt - Small Caps'", fontSize: 16}}>METAMASK</p>
             </Button>
         </Container>
     )


### PR DESCRIPTION
# Title
Create Login component

## Summary
When not connected via MetaMask, users should see a simple login page with a button to connect MetaMask. This should be added as a new React component in frontend package. Existing logic for MetaMask connect is live, can be used as is. Simply needs to be styled correctly. Attached Egg asset and screenshot of view.

## Implementation
Changed font and fixed some styles for login component and wallet modal

## Files
packages/newFront/public/index.html
packages/newFront/src/App.tsx
packages/newFront/src/views/Login.tsx

## Visual Preview
![image](https://user-images.githubusercontent.com/54931597/126721141-6c4e152c-e0f2-4d6b-a791-ac7c13db72a1.png)
![image](https://user-images.githubusercontent.com/54931597/126721160-39e12594-b927-4c8a-bdd0-d3a7e3073766.png)
